### PR TITLE
fix (switch): add support for the Switch

### DIFF
--- a/src/bulb.ts
+++ b/src/bulb.ts
@@ -65,7 +65,11 @@ export default class Bulb{
 
   public hasKelvin(){
     if (this.ProductInfo) {
-      return this.ProductInfo.features.temperature_range.reduce((a, b) => b - a) > 0;
+      if (this.ProductInfo.features.temperature_range) {
+        return this.ProductInfo.features.temperature_range.reduce((a, b) => b - a) > 0;
+      } 
+      
+      return false;
     }
     return this.HardwareInfo.productName !== 'LIFX Mini White';
   }


### PR DESCRIPTION
Currently the start up crashes as the switches don't have a temperature range property.

```
TypeError: Cannot read properties of undefined (reading 'reduce')
    at Bulb.hasKelvin (/homebridge/node_modules/homebridge-lifx-plugin/src/bulb.ts:68:58)
    at LifxPlatformAccessory.bindFunctions (/homebridge/node_modules/homebridge-lifx-plugin/src/platformAccessory.ts:62:19)
```