### PR TITLE
Simplify color temperature handling by setting range on characteristic

### DIFF
--- a/src/bulb.ts
+++ b/src/bulb.ts
@@ -173,7 +173,8 @@ export default class Bulb{
     this.States.color.hue = color.h;
     this.States.color.saturation = color.s;
 
-    this.States.color.kelvin = Bulb.convertKelvinMirek(value);
+    const range = this.getKelvinRange();
+    this.States.color.kelvin = Math.min(Math.max(range.min, Bulb.convertKelvinMirek(value)), range.max);
     this.updateKelvin(this.States, this.Settings.ColorDuration);
   }
 
@@ -198,7 +199,7 @@ export default class Bulb{
   }
 
   public static convertKelvinMirek(value){
-    return Math.round(1000000 / value);
+    return 1000000 / value;
   }
 
   public getKelvinRange(){

--- a/src/bulb.ts
+++ b/src/bulb.ts
@@ -173,7 +173,7 @@ export default class Bulb{
     this.States.color.hue = color.h;
     this.States.color.saturation = color.s;
 
-    this.States.color.kelvin = this.getKelvin(value);
+    this.States.color.kelvin = Bulb.convertKelvinMirek(value);
     this.updateKelvin(this.States, this.Settings.ColorDuration);
   }
 
@@ -194,22 +194,14 @@ export default class Bulb{
   }
 
   getColorTemperatur(){
-    const range = this.getKelvinRange();
-    let tmp = Math.round((640) / (range.max/ this.States.color.kelvin));
-    if (tmp > 500) {
-      tmp = 500;
-    } else if (tmp < 140) {
-      tmp = 140;
-    }
-    return tmp;
+    return Bulb.convertKelvinMirek(this.States.color.kelvin);
   }
 
-  public getKelvin(value){
-    const range = this.getKelvinRange();
-    return this.convertColorTemperatureFromHomeKitToKelvin(value, range.min, range.max);
+  public static convertKelvinMirek(value){
+    return Math.round(1000000 / value);
   }
 
-  private getKelvinRange(){
+  public getKelvinRange(){
     if (this.ProductInfo) {
       if (this.ProductInfo.upgrades.length > 0) {
         for (const key in this.ProductInfo.upgrades) {
@@ -261,13 +253,4 @@ export default class Bulb{
       b: Math.round(b),
     };
   }
-
-  private convertColorTemperatureFromHomeKitToKelvin(value, min, max) {
-    const scale = max;
-    const adjustedValue = (value - 71) * (max - min) / (600 - 71) + 153;
-    const convertedValue = Math.round((scale * min / (max - min)) * ((max / adjustedValue) - 1));
-    return Math.min(scale, Math.max(min, convertedValue));
-  }
-
 }
-

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -61,8 +61,8 @@ export class LifxPlatformAccessory {
 
     if (this.bulb.hasKelvin()) {
       const range = this.bulb.getKelvinRange();
-      const m_min = Bulb.convertKelvinMirek(range.max);
-      const m_max = Bulb.convertKelvinMirek(range.min);
+      const m_min = Math.floor(Bulb.convertKelvinMirek(range.max));
+      const m_max = Math.ceil(Bulb.convertKelvinMirek(range.min));
 
       this.service.getCharacteristic(this.platform.Characteristic.ColorTemperature)
         .setProps({ minValue: m_min, maxValue: m_max })

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -60,7 +60,12 @@ export class LifxPlatformAccessory {
       .onSet(this.setBrightness.bind(this));
 
     if (this.bulb.hasKelvin()) {
+      const range = this.bulb.getKelvinRange();
+      const m_min = Bulb.convertKelvinMirek(range.max);
+      const m_max = Bulb.convertKelvinMirek(range.min);
+
       this.service.getCharacteristic(this.platform.Characteristic.ColorTemperature)
+        .setProps({ minValue: m_min, maxValue: m_max })
         .onSet(this.setKelvin.bind(this));
 
       if (this.adaptiveLightingSupport()) {


### PR DESCRIPTION
Hi, first off all, thank you for this plugin! It's been working really well for me so far.

I noticed that I was unable to set the colour temperature to the full range of my bulbs. The calculation for the conversion seemed to be not quite right. In fixing it I noticed that it's possible to just tell HomeKit the actual range of supported values, which simplifies things quite a bit. 

Hope this is useful :)