### PR TITLE
Define correct kelvin range for LIFX Z

### DIFF
--- a/src/products.json
+++ b/src/products.json
@@ -276,7 +276,7 @@
         "infrared": false,
         "multizone": true,
         "temperature_range": [
-          2500,
+          1500,
           9000
         ]
       },
@@ -292,7 +292,7 @@
         "infrared": false,
         "multizone": true,
         "temperature_range": [
-          2500,
+          1500,
           9000
         ],
         "min_ext_mz_firmware": 1532997580,


### PR DESCRIPTION
Fixes https://github.com/calvarium/homebridge-lifx-plugin/issues/18

I confirmed with the LIFX iOS app that at least for `pid: 32` the minimum color temperature is 1500K as opposed to 2500K