### PR TITLE
Add full support for the LIFX Switch

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -132,6 +132,25 @@
           }
         }
       },
+      "switches": {
+        "type": "array",
+        "items": {
+          "title": "Switches",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "placeholder": "Enter switch name..."
+            },
+            "address": {
+              "type": "string",
+              "format": "hostname",
+              "placeholder": "xxx.xxx.xxx.xxx"
+            }
+          }
+        }
+      },
       "excludes": {
         "type": "array",
         "items": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "lifx-lan-client": "^1.1.0"
+        "lifx-lan-client": "bradrees/lifx-lan-client#feature/switch-support"
       },
       "devDependencies": {
         "@types/node": "^16.10.9",
@@ -1386,9 +1386,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2345,15 +2345,15 @@
       }
     },
     "node_modules/lifx-lan-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lifx-lan-client/-/lifx-lan-client-1.1.0.tgz",
-      "integrity": "sha512-gdazJkuOMlvZ9ILfiUr6F860npLHsfHhJZtRwddVyKxjIziAlbLktm5GutPA74uQi8nY7kf1dJMm3JZxouWQ8w==",
+      "version": "2.0.0",
+      "resolved": "git+ssh://git@github.com/bradrees/lifx-lan-client.git#7b455a7a8b612816b09dc6cfe1d0c69bce3d165b",
+      "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^2.0.3",
+        "eventemitter3": "^4.0.7",
         "lodash": "^4.17.15"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8.10"
       }
     },
     "node_modules/lodash": {
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mkdirp": {
@@ -4702,9 +4702,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -5413,11 +5413,10 @@
       }
     },
     "lifx-lan-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lifx-lan-client/-/lifx-lan-client-1.1.0.tgz",
-      "integrity": "sha512-gdazJkuOMlvZ9ILfiUr6F860npLHsfHhJZtRwddVyKxjIziAlbLktm5GutPA74uQi8nY7kf1dJMm3JZxouWQ8w==",
+      "version": "git+ssh://git@github.com/bradrees/lifx-lan-client.git#7b455a7a8b612816b09dc6cfe1d0c69bce3d165b",
+      "from": "lifx-lan-client@bradrees/lifx-lan-client#feature/switch-support",
       "requires": {
-        "eventemitter3": "^2.0.3",
+        "eventemitter3": "^4.0.7",
         "lodash": "^4.17.15"
       }
     },
@@ -5502,9 +5501,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "homebridge-lifx-plugin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-lifx-plugin",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "lifx-lan-client": "bradrees/lifx-lan-client#feature/switch-support"
+        "lifx-lan-client": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^16.10.9",
@@ -2345,9 +2345,9 @@
       }
     },
     "node_modules/lifx-lan-client": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/bradrees/lifx-lan-client.git#7b455a7a8b612816b09dc6cfe1d0c69bce3d165b",
-      "license": "MIT",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lifx-lan-client/-/lifx-lan-client-2.1.0.tgz",
+      "integrity": "sha512-0IS8y5xgS4J75aLh7+9cktDLQfosijBLP0EpfE/A0oNpDci6uezr3P/v8JNrLKoFnRr8GQpKbA0g1oY+3wE7LA==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "lodash": "^4.17.15"
@@ -5413,8 +5413,9 @@
       }
     },
     "lifx-lan-client": {
-      "version": "git+ssh://git@github.com/bradrees/lifx-lan-client.git#7b455a7a8b612816b09dc6cfe1d0c69bce3d165b",
-      "from": "lifx-lan-client@bradrees/lifx-lan-client#feature/switch-support",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lifx-lan-client/-/lifx-lan-client-2.1.0.tgz",
+      "integrity": "sha512-0IS8y5xgS4J75aLh7+9cktDLQfosijBLP0EpfE/A0oNpDci6uezr3P/v8JNrLKoFnRr8GQpKbA0g1oY+3wE7LA==",
       "requires": {
         "eventemitter3": "^4.0.7",
         "lodash": "^4.17.15"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
-    "prepublishOnly": "npm run lint && npm run build"
+    "prepublishOnly": "npm run lint && npm run build",
+    "prepare": "npm run build"
   },
   "keywords": [
     "homebridge-plugin",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Lifx Plugin",
   "name": "homebridge-lifx-plugin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "This plugin is a bridge between lifx smart bulbs and your apple homekit",
   "funding": {
     "type": "paypal",
@@ -38,7 +38,7 @@
     "homekit"
   ],
   "dependencies": {
-    "lifx-lan-client": "^1.1.0"
+    "lifx-lan-client": "bradrees/lifx-lan-client#feature\/switch-support"
   },
   "devDependencies": {
     "@types/node": "^16.10.9",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "homekit"
   ],
   "dependencies": {
-    "lifx-lan-client": "bradrees/lifx-lan-client#feature\/switch-support"
+    "lifx-lan-client": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^16.10.9",

--- a/src/platformSwitchAccessory.ts
+++ b/src/platformSwitchAccessory.ts
@@ -1,0 +1,102 @@
+import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
+
+import { LifxHomebridgePlatform } from './platform';
+
+import Switch from './switch';
+
+export class LifxPlatformSwitchAccessory {
+  private service: Service;
+  private watcher;
+
+  private device;
+  private readonly index;
+
+  constructor(
+    private readonly platform: LifxHomebridgePlatform,
+    public readonly Accessory: PlatformAccessory,
+    private readonly light,
+    private readonly relayIndex,
+    private readonly name,
+    settings,
+  ) {
+
+    this.device = new Switch(light, name, settings);
+    this.index = relayIndex;
+
+    this.service = this.Accessory.getService(this.platform.Service.Switch) || this.Accessory.addService(this.platform.Service.Switch);
+
+
+    this.device.Init(()=>{
+
+      this.setHardwareCharacteristics();
+      this.setSoftwareCharacteristics();
+      this.bindFunctions();
+      this.resetWatcher();
+
+    }, (error) => this.handleError(error));
+
+  }
+
+  setHardwareCharacteristics(){
+    this.Accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, this.device.getVendorName())
+      .setCharacteristic(this.platform.Characteristic.Model, this.device.getProductName())
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.device.getSerialNumber());
+  }
+
+  setSoftwareCharacteristics(){
+    const version = this.device.getVersion();
+
+    if (version !== '0.0' && this.platform.config.updates) {
+      const service = this.Accessory.getService(this.platform.Service.AccessoryInformation)!;
+      service.addCharacteristic(this.platform.Characteristic.FirmwareRevision);
+      service.setCharacteristic(this.platform.Characteristic.FirmwareRevision, version);
+    }
+    this.service.setCharacteristic(this.platform.Characteristic.Name, this.getName());
+  }
+
+  bindFunctions(){
+    this.service.getCharacteristic(this.platform.Characteristic.On)
+      .onSet(this.setOn.bind(this)) ;
+  }
+
+  async setOn(value: CharacteristicValue) {
+    this.resetWatcher();
+    this.device.setOn(this.index, value);
+    this.platform.log.debug('Set Characteristic On ->', [value, this.index]);
+  }
+
+  handleError(err){
+    this.platform.log.warn('Bulb ' + this.getName() + ' throughs error', err);
+    // if you need to return an error to show the device as "Not Responding" in the Home app:
+    // throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+  }
+
+  async watchState(){
+    this.watcher = setInterval(() => {
+      this.device.updateStates(this.index, () => {
+        this.updateLightbuldCharacteristics();
+        this.platform.log.debug('updated', this.getName());
+      });
+    }, 5000);
+  }
+
+  async resetWatcher(){
+    if (this.watcher) {
+      clearInterval(this.watcher);
+    }
+    this.watchState();
+  }
+
+  async updateLightbuldCharacteristics(){
+    this.updateOn();
+  }
+
+  updateOn() {
+    this.service.updateCharacteristic(this.platform.Characteristic.On, this.device.getOn(this.index));
+  }
+
+  getName() {
+    return this.device.getName() + ' ' + (this.index + 1);
+  }
+}

--- a/src/switch.ts
+++ b/src/switch.ts
@@ -1,0 +1,164 @@
+/* eslint-disable max-len */
+import LIFX from './products.json';
+import ProductInfo from './IProductInfo';
+export default class Switch{
+  private ProductInfo? : ProductInfo;
+
+  private States = {
+    power: [0, 0, 0, 0],
+    label: '',
+  };
+
+  private HardwareInfo = {
+    vendorName : 'LIFX',
+    productName : 'Unknown',
+    productFeatures : { buttons: true },
+  };
+
+  private FirmwareVersion = {
+    majorVersion : 0,
+    minorVersion : 0,
+  };
+
+  constructor(
+    private readonly light,
+    private readonly name,
+    private readonly Settings){
+  }
+
+  public async Init(callback, error){
+    this.setFirmwareVersion(err => error(err));
+    this.setHardwareInformation(() => {
+      this.ProductInfo = Switch.getProductInfo(this.HardwareInfo.productName);
+      this.States.label = this.name;
+      for (let i = 0; i < 4; i++) {
+        this.updateStates(i, () => {
+          if (i === 3) {
+            callback();
+          }
+        });
+      }
+    }, err => error(err));
+  }
+
+  public getName(){
+    return this.States.label;
+  }
+
+  public getVersion(){
+    return this.FirmwareVersion.majorVersion + '.' + this.FirmwareVersion.minorVersion;
+  }
+
+  public getSerialNumber(){
+    return this.light.id;
+  }
+
+  public getVendorName(){
+    return this.HardwareInfo.vendorName;
+  }
+
+  public getProductName(){
+    return this.HardwareInfo.productName;
+  }
+
+  public hasButtons(){
+    if (this.ProductInfo) {
+      return this.ProductInfo.features.buttons;
+    }
+    return this.HardwareInfo.productFeatures.buttons;
+  }
+
+  async updateStates(index, callback){
+    this.getStates(index, (state) => {
+      if (state !== null) {
+        this.setPower(index, state);
+      } else {
+        this.setPower(index, 0);
+      }
+      callback();
+    }, () => {
+      this.setPower(index, 0);
+      callback();
+    });
+
+    this.getLabel((label) => {
+      if (label !== null) {
+        this.States.label = label;
+      }
+    }, () => {
+      this.States.label = this.States.label || '';
+    });
+  }
+
+  private static getProductInfo(productName) : ProductInfo{
+    return LIFX.products.find((x) => x.name === productName) as ProductInfo;
+  }
+
+  private setPower(index, value){
+    this.States.power[index] = value;
+  }
+
+  async setFirmwareVersion(error){
+    this.getFirmwareVersion((version) => {
+      this.FirmwareVersion = version;
+    }, (err) => error('setFirmwareVersion' + err));
+  }
+
+  async setHardwareInformation(callback, error){
+    this.getHardwareInformation((info) => {
+      this.HardwareInfo = info;
+      callback();
+    }, (err) => error('setHardwareInformation' + err));
+  }
+
+  getStates(index, callback, errorFallback){
+    this.light.getRelayPower(index, (err, value) => {
+      if (err) {
+        errorFallback(err);
+      }
+      callback(value);
+    });
+  }
+
+  getHardwareInformation(callback, errorFallback){
+    this.light.getHardwareVersion((err, value) => {
+      if (err) {
+        errorFallback(err);
+      }
+      callback(value);
+    });
+  }
+
+  getFirmwareVersion(callback, errorFallback){
+    this.light.getFirmwareVersion((err, value) => {
+      if (err) {
+        errorFallback(err);
+      }
+      callback(value);
+    });
+  }
+
+  getLabel(callback, errorFallback){
+    this.light.getLabel((err, value) => {
+      if (err) {
+        errorFallback(err);
+      }
+      callback(value);
+    });
+  }
+
+  async setOn(index, value) {
+    this.States.power[index] = value;
+
+    if (this.States.power[index] > 0) {
+      this.light.relayOn(index);
+    } else{
+      this.light.relayOff(index);
+    }
+  }
+
+  getOn(index) {
+    return this.States.power[index];
+  }
+}
+


### PR DESCRIPTION
I created this a while back, but have only recently had my changes merged in the node-lifx (https://github.com/node-lifx/lifx-lan-client/pull/50) library to support the switch. I've been using this with a number of Switches and Bulbs in my house with Homekit and it works great. It actually adds a lot of functionality to the switches as each switch/relay cannot usually be addressed separately in any workflows or automation.

Thanks for the great library!