### PR TITLE
Missing productFeatures caused a crash in my installation in bulb.js at hasKelvin and later on in hasColor

### DIFF
--- a/src/bulb.ts
+++ b/src/bulb.ts
@@ -57,19 +57,19 @@ export default class Bulb{
   }
 
   public hasColors(){
-    return this.HardwareInfo?.productFeatures.color;
+    return this.HardwareInfo?.productFeatures?.color;
   }
 
   public hasKelvin(){
-    return this.HardwareInfo?.productFeatures.temperature_range?.reduce((a, b) => b - a) || 0 > 0;
+    return this.HardwareInfo?.productFeatures?.temperature_range?.reduce((a, b) => b - a) || 0 > 0;
   }
 
   public getMinKelvin(){
-    return Math.min(... this.HardwareInfo?.productFeatures.temperature_range || []);
+    return Math.min(... this.HardwareInfo?.productFeatures?.temperature_range || []);
   }
 
   public getMaxKelvin(){
-    return Math.max(... this.HardwareInfo?.productFeatures.temperature_range || []);
+    return Math.max(... this.HardwareInfo?.productFeatures?.temperature_range || []);
   }
 
   public getMinColorTemperatur(){


### PR DESCRIPTION
Obviously productFeatures are not always included. The ? at the 2 hasXXX functions solved my problem. The ? at getXXX are only for good measure.