### PR TITLE
Bump version of lifx lan client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "lifx-lan-client": "^1.1.0"
+        "lifx-lan-client": "^2.1.2"
       },
       "devDependencies": {
         "@types/node": "^16.10.9",
@@ -1178,9 +1178,10 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2034,15 +2035,16 @@
       }
     },
     "node_modules/lifx-lan-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lifx-lan-client/-/lifx-lan-client-1.1.0.tgz",
-      "integrity": "sha512-gdazJkuOMlvZ9ILfiUr6F860npLHsfHhJZtRwddVyKxjIziAlbLktm5GutPA74uQi8nY7kf1dJMm3JZxouWQ8w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lifx-lan-client/-/lifx-lan-client-2.1.2.tgz",
+      "integrity": "sha512-SNda50VkeccMxsW0B+TVhW/pzVWByyR4fJjYCVzTJDWv4uO1bCJOM9PhHBBHHurvcAXwTL6OmeC3d2X6JzXFcg==",
+      "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^2.0.3",
+        "eventemitter3": "^5.0.1",
         "lodash": "^4.17.15"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8.10"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "homekit"
   ],
   "dependencies": {
-    "lifx-lan-client": "^2.1.0"
+    "lifx-lan-client": "^2.1.2"
   },
   "devDependencies": {
     "@types/node": "^16.10.9",


### PR DESCRIPTION
Bump the version of the lifx lan client. This brings in the definition of new devices introduced in version 2.1.1. 

When tested against a LIFX Neon it seems to solve the `TypeError: Cannot read properties of undefined (reading 'color')` error mentioned in #40 and others.