### PR TITLE
FIX: Cannot read properties of undefined (reading 'color') Added null-safe access to productFeatures.

### DIFF
--- a/src/bulb.ts
+++ b/src/bulb.ts
@@ -57,7 +57,7 @@ export default class Bulb{
   }
 
   public hasColors(){
-    return this.HardwareInfo?.productFeatures.color;
+    return this.HardwareInfo?.productFeatures?.color;
   }
 
   public hasKelvin(){
@@ -65,11 +65,11 @@ export default class Bulb{
   }
 
   public getMinKelvin(){
-    return Math.min(... this.HardwareInfo?.productFeatures.temperature_range || []);
+    return Math.min(... (this.HardwareInfo?.productFeatures?.temperature_range || []));
   }
 
   public getMaxKelvin(){
-    return Math.max(... this.HardwareInfo?.productFeatures.temperature_range || []);
+    return Math.max(... (this.HardwareInfo?.productFeatures?.temperature_range || []));
   }
 
   public getMinColorTemperatur(){


### PR DESCRIPTION
Fixes crash loop when new LIFX products are discovered, as they don't have productFeatures defined. Fixes issue #40